### PR TITLE
Readable email, open email client on click

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -4,6 +4,6 @@
 [ports](http://github.com/mitchweaver/bonsai/tree/master/ports)  
 [packages](http://bonsai-linux.org/pkgs)  
 [discord server](http://discord.gg/FwbTB9R)  
-[email](dev@bonsai-linux.org)
+email: <dev@bonsai-linux.org>
 
 *(under construction)*


### PR DESCRIPTION
Email should be readable to allow people to easily copy it.
<link> is a short version of [link](link), also it detects (on some markdown to html converters), if the link is an email and if it is, makes the link `mailto:email`